### PR TITLE
Plug=none on directories

### DIFF
--- a/none.html
+++ b/none.html
@@ -18,7 +18,6 @@
   }}
 </ul>
 
-<!-- <script src=https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js></script> -->
 <script src=/lib/js/scout.js?plug=none></script>
 
 <!-- Google Analytics -->


### PR DESCRIPTION
The simplest way to configure the option plug=none on directories is to have a template.
Here is a first template (basically, the Gateway, without the css and js).
