### PR TITLE
[Gateway] Move search depth from 4 back to 3

### DIFF
--- a/lib/js/gateway.js
+++ b/lib/js/gateway.js
@@ -75,7 +75,7 @@
   // Request information about the contents of a directory to the server.
   /* function getfs(query) {
     query.action = 'fs';
-    query.data = {op:'read', path:cwd};
+    query.data = {op: 'read', path: cwd};
     query.resp = function (data) {
       if (!data.err) setfiles(data.files);
     };
@@ -188,7 +188,7 @@ addEventListener('load', function () {
   pathreq.addEventListener('input', function firstfuzzy() {
     Scout.send(function(q) {
       q.action = 'fs';
-      q.data = {op:'read', path:cwd, depth:depth};
+      q.data = {op: 'read', path: cwd, depth: depth};
       q.resp = function (r) {
         leaves = r.files;
         pathreq.removeEventListener('input', firstfuzzy, false);


### PR DESCRIPTION
@espadrine haha, I bet you didn't notice that I went from 2 to 4 in the first place! Recursive `read` is somehow faster than recursive `ls` was, so I bumped the depth, but trying it on https://thefiletree.com I found it a little too slow. `3` should be ok.
