### PR TITLE
Keep toolbar visible during scroll. Move filelist down 2em not to be obs...

### DIFF
--- a/lib/css/ui.css
+++ b/lib/css/ui.css
@@ -24,7 +24,7 @@ html, body {
   font-size: 16px;
   line-height: 16px;
   padding: 0 4px 0 0;
-  position: relative;
+  position: fixed;
   box-shadow: 0 2px 2px rgba(0,0,0,0.1);
   z-index: 20;
 }
@@ -144,6 +144,8 @@ html, body {
 
 #filelist {
   overflow: auto;
+  position: relative;
+  top: 2em;
 }
 #filelist li {
   padding: 5px;

--- a/pencil.html
+++ b/pencil.html
@@ -25,7 +25,7 @@
      'lesser-dark','monokai','neat','night','rubyblue','vibrant-ink','xq-dark']|theme|i;
     <option{{?theme===lookup('theme'); selected}}>{{=theme|html}}</option>}}
   </select>
-  <a class="item right" id=download title=download><img src=/lib/icons/download_alt.png></a>
+  <a class="item right" id=download title=download download><img src=/lib/icons/download_alt.png></a>
   <input type=hidden name=code>
   <input type=hidden name=file>
   <input type=hidden name=lang>


### PR DESCRIPTION
...cured by toolbar. Add download attribute to download anchor to enable download to local disk.

Please have a look and let me know if you agree with these little usability changes.

The scrolling fix should be a definite UX improvement.

I am not sure whether my download attribute change is in line with your overall design.

It really does a one-click download to local disk now.

I like the garden tree idea!

Regards, anaran
