### PR TITLE
Leave small gap to left of toolbar, fix path quoting in pencil.html

### DIFF
--- a/lib/css/ui.css
+++ b/lib/css/ui.css
@@ -22,11 +22,10 @@ html, body {
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);
   background-color: #f9f9f9;
   font-size: 16px;
-  left: 0;
   line-height: 16px;
-  width: 100%;
   padding: 0 4px 0 0;
   position: fixed;
+  left: 4em;
   right: 0;
   box-shadow: 0 2px 2px rgba(0,0,0,0.1);
   z-index: 20;
@@ -148,7 +147,7 @@ html, body {
 #filelist {
   overflow: auto;
   position: relative;
-  top: 2em;
+  top: 0;
 }
 #filelist:hover {
   background-color: white;
@@ -191,7 +190,7 @@ html, body {
   border-bottom: 0;
   height: 100%;
 }
-.CodeMirror-scroll:hover {
+.CodeMirror:hover {
   background-color: white;
   z-index: 30;
 }

--- a/pencil.html
+++ b/pencil.html
@@ -56,7 +56,7 @@
 
     // Template information
     var socket = Scout.socket({{=file.path|json}}),
-        path = '{{=file.path|uri}}',
+        path = "{{=file.path|uri}}",
         mime = {{=
             file.meta.type? file.meta.type:
             lookup('types["' + extname + '"]') |json}} || 'text/plain',


### PR DESCRIPTION
Leave small gap to left of toolbar, fix path quoting in pencil.html
Force 4em gap on the left of toolbar for first line of file or first
entry in filelist to be visible.
Double-quote Scout.socket path argument so that file names including
single-quotes become useable (currently causes file to be inaccessible
after creation).

NB: There are still three commits in there that are before the current branch off point of scroll_download. I was not able to eliminate them with rebase.

I suggest to execute this pull request as it is.
