### PR TITLE
Unicode fix

### DIFF
--- a/lib/js/gateway.js
+++ b/lib/js/gateway.js
@@ -57,7 +57,7 @@
   } */
 
   // common working directory.
-  var cwd = unescape(document.location.pathname);
+  var cwd = decodeURIComponent(document.location.pathname);
   if (cwd[cwd.length-1] !== '/') cwd += '/';
   window.cwd = cwd;
 


### PR DESCRIPTION
@jankeromnes, this fixes the following issue:
1. Create a folder くらす
2. Open it
3. Create a file
4. It fails to go to that file
